### PR TITLE
Update $.js

### DIFF
--- a/src/$.js
+++ b/src/$.js
@@ -2,14 +2,12 @@
 $ = (function (document, window, $) {
   // Node covers all elements, but also the document objects
   var node = Node.prototype,
-      nodeList = NodeList.__proto__ || NodeList.prototype,
+      nodeList = NodeList.prototype,
       forEach = 'forEach',
       trigger = 'trigger',
       each = [][forEach],
       // note: createElement requires a string in Firefox
       dummy = document.createElement('i');
-
-  nodeList[forEach] = each;
 
   // we have to explicitly add a window.on as it's not included
   // in the Node object.


### PR DESCRIPTION
`nodeList` should refer to `NodeList.prototype` instead of its `.__proto__`.

The line `nodeList[forEach] = each;` is not needed as you're iterating `NodeList` instances by invoking `Array.prototype.each` directly and passing the `NodeList` instance via `.call()`.
